### PR TITLE
Tanzu Hub Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,11 @@ repositories {
 }
 
 dependencies {
+	implementation(platform('com.wavefront:wavefront-spring-boot-bom:3.2.0'))
 	implementation(platform('software.amazon.awssdk:bom:2.31.69'))
 
+	implementation 'com.wavefront:wavefront-spring-boot-starter'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 	implementation 'io.pivotal.cfenv:java-cfenv-boot:3.4.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -32,5 +35,7 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-bindings:2.0.4'
 	implementation 'software.amazon.awssdk:imds'
 
+	runtimeOnly 'io.micrometer:micrometer-registry-wavefront'
+	runtimeOnly 'io.micrometer:micrometer-tracing-reporter-wavefront'
 	runtimeOnly 'software.amazon.awssdk:aws-crt-client'
 }

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,8 +12,7 @@ applications:
     JBP_CONFIG_OPEN_JDK_JRE: '{jre: {version: 21.+ },memory_calculator: {stack_threads: 50}}'
     JAVA_OPTS: >-
       -XX:MaxDirectMemorySize=128M
-      -Dmanagement.endpoint.health.probes.add-additional-paths=true
-      -Dmanagement.health.probes.enabled=true
+      -Dspring.profiles.active=cloud-foundry,tanzu-hub
 
   health-check-type: http
   health-check-http-endpoint: /livez

--- a/src/main/resources/application-cloud-foundry.properties
+++ b/src/main/resources/application-cloud-foundry.properties
@@ -1,0 +1,2 @@
+management.endpoint.health.probes.add-additional-paths=true
+management.endpoint.health.probes.enabled=true

--- a/src/main/resources/application-tanzu-hub.properties
+++ b/src/main/resources/application-tanzu-hub.properties
@@ -1,0 +1,6 @@
+management.wavefront.api-token=1111-23this-45is-678a-faketoken
+management.wavefront.application.name=Tanzu Business Application
+management.wavefront.application.custom-tags.instance_guid=${CF_INSTANCE_GUID}
+management.wavefront.metrics.export.enabled=true
+management.wavefront.tracing.export.enabled=true
+management.wavefront.uri=http://telegraf.hub-collector.service.internal:8765

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,7 @@
-management.endpoints.web.exposure.include=health,info
-spring.application.name=Tanzu Java Web Application
+management.endpoints.web.exposure.include=health,info,metrics
+management.tracing.sampling.probability=0.5
+management.wavefront.metrics.export.enabled=false
+management.wavefront.tracing.export.enabled=false
 logging.level.software.amazon.awssdk.imds.internal=off
 logging.pattern.console=[%clr(%-5p)] %m%n
+spring.application.name=Tanzu Java Web Application


### PR DESCRIPTION
This change adds support for integrations with Tanzu Hub.  Today, this
support is limited to metrics and tracing, but can be extended in the
future.  To enable this support, add 'tanzu-hub' to the list of active Spring
profiles.

Signed-off-by: Ben Hale <ben.hale@broadcom.com>
