### PR TITLE
Reduce Dependabot Rate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
 - package-ecosystem: gradle
   directory: /
   schedule:
-    interval: daily
+    interval: weekly
   labels:
   - dependencies
 


### PR DESCRIPTION
This changes the frequency of Dependabot's updates to weekly. This is to
reduce the number of pull requests created by Dependabot, which is a bit
too high due to Amazon's release cadence.

Signed-off-by: Ben Hale <ben.hale@broadcom.com>
